### PR TITLE
Merge the parsing and evaluation steps into one

### DIFF
--- a/src/DOMManipulation.ts
+++ b/src/DOMManipulation.ts
@@ -1,4 +1,4 @@
-import { parse } from "./Parser";
+import { parseAndEvaluate } from "./Parser";
 
 const input: HTMLDivElement | null = document.querySelector(".input");
 
@@ -65,7 +65,7 @@ export function printResult() {
 
       if (expr) {
         try {
-          result = parse(expr);
+          result = parseAndEvaluate(expr);
           input.textContent = result.toString();
         } catch (err) {
           console.error(err);

--- a/src/DOMManipulation.ts
+++ b/src/DOMManipulation.ts
@@ -65,8 +65,7 @@ export function printResult() {
 
       if (expr) {
         try {
-          const tokens = parse(expr);
-          result = evaluate(tokens);
+          result = parse(expr);
           input.textContent = result.toString();
         } catch (err) {
           console.error(err);

--- a/src/DOMManipulation.ts
+++ b/src/DOMManipulation.ts
@@ -1,4 +1,4 @@
-import { evaluate, parse } from "./Parser";
+import { parse } from "./Parser";
 
 const input: HTMLDivElement | null = document.querySelector(".input");
 

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -4,7 +4,6 @@ import {
   processRightBracket,
   processOperator,
   parse,
-  evaluate,
 } from "./Parser";
 
 import { describe, expect, it } from "vitest";

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -46,7 +46,7 @@ describe("processRightBracket", () => {
 
     processRightBracket(stack, output);
 
-    expect(output).toStrictEqual(["4", "3", "2"]);
+    expect(output).toStrictEqual([]);
     expect(stack.peek()).toBe("1");
   });
 });

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -97,8 +97,8 @@ describe("processOperator", () => {
   });
 });
 
-describe("parse", () => {
-  it("converts an infix expression into Reverse Polish Notation", () => {
+describe("parseAndEvaluate", () => {
+  it("converts an infix expression into Reverse Polish Notation and evaluates it", () => {
     expect(parseAndEvaluate("1 + 1 - 2")).toBe(0);
     expect(parseAndEvaluate("1 + 1 - 2 × 4 + 8 ÷ 2 - 1")).toBe(-3);
   });

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -36,7 +36,7 @@ describe("isNumber", () => {
 describe("processRightBracket", () => {
   it("Pushes result of calling evaluate with stack contents into the output array until it encounters a left bracket", () => {
     const stack = new Stack<string>();
-    const output: string[] = ["1", "2", "3", "4"];
+    const output: number[] = [1, 2, 3, 4];
 
     stack.push("÷");
     stack.push("(");
@@ -46,13 +46,13 @@ describe("processRightBracket", () => {
 
     processRightBracket(stack, output);
 
-    expect(output).toStrictEqual(["1"]);
+    expect(output).toStrictEqual([1]);
     expect(stack.peek()).toBe("÷");
   });
 
   it("Leaves the output array unmodified if it has less than 2 entries", () => {
     const stack = new Stack<string>();
-    const output: string[] = [];
+    const output: number[] = [];
 
     stack.push("÷");
     stack.push("(");
@@ -70,7 +70,7 @@ describe("processRightBracket", () => {
 describe("processOperator", () => {
   it("Pushes the given operator to the stack if the stack was initially empty", () => {
     const stack = new Stack<string>();
-    const output: string[] = [];
+    const output: number[] = [];
 
     processOperator("+", stack, output);
 
@@ -79,7 +79,7 @@ describe("processOperator", () => {
 
   it("Pushes the current operator on the stack if it has a greater precedence than the one at the top of the stack", () => {
     const stack = new Stack<string>();
-    const output: string[] = [];
+    const output: number[] = [];
 
     stack.push("×");
 
@@ -90,7 +90,7 @@ describe("processOperator", () => {
 
   it("Pushes the current operator on the stack if the top of the stack is a ( character", () => {
     const stack = new Stack<string>();
-    const output: string[] = [];
+    const output: number[] = [];
 
     stack.push("(");
 
@@ -101,7 +101,7 @@ describe("processOperator", () => {
 
   it("Pops operators from the stack and pushes the result of calling evaluate onto the output queue if the current operator has lower precedence", () => {
     const stack = new Stack<string>();
-    const output: string[] = ["1", "2", "3", "4"];
+    const output: number[] = [1, 2, 3, 4];
 
     stack.push("+");
     stack.push("×");
@@ -110,12 +110,12 @@ describe("processOperator", () => {
     processOperator("-", stack, output);
 
     expect(stack.peek()).toBe("-");
-    expect(output).toStrictEqual(["2.5"]);
+    expect(output).toStrictEqual([2.5]);
   });
 
   it("Leaves the output array unmodified if it has less than 2 entries", () => {
     const stack = new Stack<string>();
-    const output: string[] = [];
+    const output: number[] = [];
 
     stack.push("+");
     stack.push("×");
@@ -137,7 +137,7 @@ describe("parseAndEvaluate", () => {
 
 describe("evaluate", () => {
   it("returns early if the output array has less than 2 entries", () => {
-    let output: string[] = [];
+    let output: number[] = [];
 
     evaluate("+", output);
 
@@ -145,30 +145,30 @@ describe("evaluate", () => {
   });
 
   it("Pushes the difference of its entries to the output array when called with the - operator", () => {
-    let output: string[] = ["1", "2"];
+    let output: number[] = [1, 2];
 
     evaluate("-", output);
-    expect(output).toStrictEqual(["-1"]);
+    expect(output).toStrictEqual([-1]);
   });
 
   it("Pushes the sum of its entries  to the output array when called with the + operator", () => {
-    let output: string[] = ["1", "2"];
+    let output: number[] = [1, 2];
 
     evaluate("+", output);
-    expect(output).toStrictEqual(["3"]);
+    expect(output).toStrictEqual([3]);
   });
 
   it("Pushes the product of its entries  to the output array when called with the × operator", () => {
-    let output: string[] = ["1", "2"];
+    let output: number[] = [1, 2];
 
     evaluate("×", output);
-    expect(output).toStrictEqual(["2"]);
+    expect(output).toStrictEqual([2]);
   });
 
   it("Pushes the quotient of its entries  to the output array when called with the ÷ operator", () => {
-    let output: string[] = ["1", "2"];
+    let output: number[] = [1, 2];
 
     evaluate("÷", output);
-    expect(output).toStrictEqual(["0.5"]);
+    expect(output).toStrictEqual([0.5]);
   });
 });

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -54,11 +54,11 @@ describe("processRightBracket", () => {
     const stack = new Stack<string>();
     const output: string[] = [];
 
-    stack.push("1");
+    stack.push("÷");
     stack.push("(");
-    stack.push("2");
-    stack.push("3");
-    stack.push("4");
+    stack.push("×");
+    stack.push("+");
+    stack.push("-");
 
     processRightBracket(stack, output);
 

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -96,6 +96,8 @@ describe("processOperator", () => {
     expect(stack.peek()).toBe("-");
     expect(output).toStrictEqual(["2.5"]);
   });
+
+  it("Leaves the output array unmodified if it has less than 2 entries", () => {
     const stack = new Stack<string>();
     const output: string[] = [];
 

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -69,7 +69,7 @@ describe("processOperator", () => {
 
     processOperator("÷", stack, output);
 
-    expect(stack.peek()).toEqual("÷");
+    expect(stack.peek()).toBe("÷");
   });
 
   it("Pushes the current operator on the stack if the top of the stack is a ( character", () => {

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -46,7 +46,7 @@ describe("processRightBracket", () => {
 
     processRightBracket(stack, output);
 
-    expect(output).toEqual(["4", "3", "2"]);
+    expect(output).toStrictEqual(["4", "3", "2"]);
     expect(stack.peek()).toBe("1");
   });
 });
@@ -94,7 +94,7 @@ describe("processOperator", () => {
     processOperator("-", stack, output);
 
     expect(stack.peek()).toBe("-");
-    expect(output).toEqual(["÷", "×", "+"]);
+    expect(output).toStrictEqual(["÷", "×", "+"]);
   });
 });
 
@@ -111,7 +111,7 @@ describe("evaluate", () => {
 
     evaluate("+", output);
 
-    expect(output).toEqual([]);
+    expect(output).toStrictEqual([]);
   });
 
   it("Pushes the difference of its entries to the output array when called with the - operator", () => {

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -83,7 +83,19 @@ describe("processOperator", () => {
     expect(stack.peek()).toBe("÷");
   });
 
-  it("Pops operators from the stack onto the output queue if the current operator has lower precedence", () => {
+  it("Pops operators from the stack and pushes the result of calling evaluate onto the output queue if the current operator has lower precedence", () => {
+    const stack = new Stack<string>();
+    const output: string[] = ["1", "2", "3", "4"];
+
+    stack.push("+");
+    stack.push("×");
+    stack.push("÷");
+
+    processOperator("-", stack, output);
+
+    expect(stack.peek()).toBe("-");
+    expect(output).toStrictEqual(["2.5"]);
+  });
     const stack = new Stack<string>();
     const output: string[] = [];
 

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -100,22 +100,8 @@ describe("processOperator", () => {
 
 describe("parse", () => {
   it("converts an infix expression into Reverse Polish Notation", () => {
-    expect(parse("1 + 1 - 2")).toEqual(["1", "1", "+", "2", "-"]);
-    expect(parse("1 + 1 - 2 × 4 + 8 ÷ 2 - 1")).toEqual([
-      "1",
-      "1",
-      "+",
-      "2",
-      "4",
-      "×",
-      "-",
-      "8",
-      "2",
-      "÷",
-      "+",
-      "1",
-      "-",
-    ]);
+    expect(parse("1 + 1 - 2")).toBe(0);
+    expect(parse("1 + 1 - 2 × 4 + 8 ÷ 2 - 1")).toBe(-3);
   });
 });
 

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -63,7 +63,7 @@ describe("processRightBracket", () => {
     processRightBracket(stack, output);
 
     expect(output).toStrictEqual([]);
-    expect(stack.peek()).toBe("1");
+    expect(stack.peek()).toBe("÷");
   });
 });
 

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -106,7 +106,7 @@ describe("parseAndEvaluate", () => {
 });
 
 describe("evaluate", () => {
-  it("returns early if the output array is empty", () => {
+  it("returns early if the output array has less than 2 entries", () => {
     let output: string[] = [];
 
     evaluate("+", output);

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -3,7 +3,7 @@ import {
   isNumber,
   processRightBracket,
   processOperator,
-  parse,
+  parseAndEvaluate,
 } from "./Parser";
 
 import { describe, expect, it } from "vitest";
@@ -99,7 +99,7 @@ describe("processOperator", () => {
 
 describe("parse", () => {
   it("converts an infix expression into Reverse Polish Notation", () => {
-    expect(parse("1 + 1 - 2")).toBe(0);
-    expect(parse("1 + 1 - 2 × 4 + 8 ÷ 2 - 1")).toBe(-3);
+    expect(parseAndEvaluate("1 + 1 - 2")).toBe(0);
+    expect(parseAndEvaluate("1 + 1 - 2 × 4 + 8 ÷ 2 - 1")).toBe(-3);
   });
 });

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -49,6 +49,22 @@ describe("processRightBracket", () => {
     expect(output).toStrictEqual([]);
     expect(stack.peek()).toBe("1");
   });
+
+  it("Leaves the output array unmodified if it has less than 2 entries", () => {
+    const stack = new Stack<string>();
+    const output: string[] = [];
+
+    stack.push("1");
+    stack.push("(");
+    stack.push("2");
+    stack.push("3");
+    stack.push("4");
+
+    processRightBracket(stack, output);
+
+    expect(output).toStrictEqual([]);
+    expect(stack.peek()).toBe("1");
+  });
 });
 
 describe("processOperator", () => {

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -113,4 +113,32 @@ describe("evaluate", () => {
 
     expect(output).toEqual([]);
   });
+
+  it("Pushes the difference of its entries to the output array when called with the - operator", () => {
+    let output: string[] = ["1", "2"];
+
+    evaluate("-", output);
+    expect(output).toStrictEqual(["-1"]);
+  });
+
+  it("Pushes the sum of its entries  to the output array when called with the + operator", () => {
+    let output: string[] = ["1", "2"];
+
+    evaluate("+", output);
+    expect(output).toStrictEqual(["3"]);
+  });
+
+  it("Pushes the product of its entries  to the output array when called with the × operator", () => {
+    let output: string[] = ["1", "2"];
+
+    evaluate("×", output);
+    expect(output).toStrictEqual(["2"]);
+  });
+
+  it("Pushes the quotient of its entries  to the output array when called with the ÷ operator", () => {
+    let output: string[] = ["1", "2"];
+
+    evaluate("÷", output);
+    expect(output).toStrictEqual(["0.5"]);
+  });
 });

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -104,12 +104,3 @@ describe("parse", () => {
     expect(parse("1 + 1 - 2 × 4 + 8 ÷ 2 - 1")).toBe(-3);
   });
 });
-
-describe("evaluate", () => {
-  it("evaluates a given mathematical expression", () => {
-    const expr = parse("1 + 1 - 2 × 4 + 8 ÷ 2 - 1");
-    const result = evaluate(expr);
-
-    expect(result).toBe(-3);
-  });
-});

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -34,20 +34,20 @@ describe("isNumber", () => {
 });
 
 describe("processRightBracket", () => {
-  it("Pushes stack contents into the output array until it encounters a left bracket", () => {
+  it("Pushes result of calling evaluate with stack contents into the output array until it encounters a left bracket", () => {
     const stack = new Stack<string>();
-    const output: string[] = [];
+    const output: string[] = ["1", "2", "3", "4"];
 
-    stack.push("1");
+    stack.push("÷");
     stack.push("(");
-    stack.push("2");
-    stack.push("3");
-    stack.push("4");
+    stack.push("×");
+    stack.push("+");
+    stack.push("-");
 
     processRightBracket(stack, output);
 
-    expect(output).toStrictEqual([]);
-    expect(stack.peek()).toBe("1");
+    expect(output).toStrictEqual(["1"]);
+    expect(stack.peek()).toBe("÷");
   });
 
   it("Leaves the output array unmodified if it has less than 2 entries", () => {

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -4,6 +4,7 @@ import {
   processRightBracket,
   processOperator,
   parseAndEvaluate,
+  evaluate,
 } from "./Parser";
 
 import { describe, expect, it } from "vitest";
@@ -101,5 +102,15 @@ describe("parseAndEvaluate", () => {
   it("converts an infix expression into Reverse Polish Notation and evaluates it", () => {
     expect(parseAndEvaluate("1 + 1 - 2")).toBe(0);
     expect(parseAndEvaluate("1 + 1 - 2 × 4 + 8 ÷ 2 - 1")).toBe(-3);
+  });
+});
+
+describe("evaluate", () => {
+  it("returns early if the output array is empty", () => {
+    let output: string[] = [];
+
+    evaluate("+", output);
+
+    expect(output).toEqual([]);
   });
 });

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -94,7 +94,7 @@ describe("processOperator", () => {
     processOperator("-", stack, output);
 
     expect(stack.peek()).toBe("-");
-    expect(output).toStrictEqual(["÷", "×", "+"]);
+    expect(output).toStrictEqual([]);
   });
 });
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -101,6 +101,10 @@ export function parseAndEvaluate(expr: string): number {
  * @param output A buffer containing the intermediate results
  */
 export function evaluate(operator: string, output: string[]) {
+  if (output.length === 0) {
+    return;
+  }
+
   const right = parseFloat(output.pop()!);
   const left = parseFloat(output.pop()!);
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -160,34 +160,3 @@ export function parse(expr: string): number {
 
   return parseFloat(output[0]);
 }
-
-/**
- * Evaluate an arithmetic expression and return the result
- * @param expr An arithmetic expression in postfix (or Reverse Polish) notation
- * @returns The result of evaluating the expression
- */
-export function evaluate(expr: string[]): number {
-  const stack = new Stack<number>();
-
-  for (let token of expr) {
-    if (!isOperator(token)) {
-      stack.push(parseInt(token));
-      continue;
-    } else {
-      const second = stack.pop();
-      const first = stack.pop();
-
-      if (token === "-") {
-        stack.push(subtract(first, second));
-      } else if (token === "+") {
-        stack.push(add(first, second));
-      } else if (token === "×") {
-        stack.push(multiply(first, second));
-      } else if (token === "÷") {
-        stack.push(divide(first, second));
-      }
-    }
-  }
-
-  return stack.peek();
-}

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -108,9 +108,9 @@ export function processRightBracket(stack: Stack<string>, output: string[]) {
 }
 
 /**
- * Parse an arithmetic expression from infix form to Reverse Polish Notation
+ * Parse an arithmetic expression from infix form to Reverse Polish Notation and evaluate it
  * @param expr The mathematical expression in infix form to be parsed
- * @returns The expression in Reverse Polish Notation
+ * @returns The result of evaluating the expression
  */
 export function parseAndEvaluate(expr: string): number {
   const stack = new Stack<string>();

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -124,7 +124,7 @@ export function parseAndEvaluate(expr: string): number {
     }
   }
 
-  while (!stack.empty()) {
+  while (!stack.empty() && stack.peek() != "(") {
     // output.push(stack.pop());
     const operator = stack.pop();
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -148,3 +148,27 @@ export function parseAndEvaluate(expr: string): number {
 
   return parseFloat(output[0]);
 }
+
+/**
+ * Perform an operation depending on the given operator
+ * @param operator The arithmetic operator
+ * @param output A buffer containing the intermediate results
+ */
+export function evaluate(operator: string, output: string[]) {
+  const right = parseFloat(output.pop()!);
+  const left = parseFloat(output.pop()!);
+
+  if (operator === "-") {
+    output.push(subtract(left, right).toString());
+  } else if (operator === "+") {
+    output.push(add(left, right).toString());
+  } else if (operator === "×") {
+    output.push(multiply(left, right).toString());
+  } else if (operator === "÷") {
+    output.push(divide(left, right).toString());
+  } else if (operator === "^") {
+    output.push((left ** right).toString());
+  } else {
+    throw new Error(`Invalid operation: ${operator}`);
+  }
+}

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -112,7 +112,7 @@ export function processRightBracket(stack: Stack<string>, output: string[]) {
  * @param expr The mathematical expression in infix form to be parsed
  * @returns The expression in Reverse Polish Notation
  */
-export function parse(expr: string): number {
+export function parseAndEvaluate(expr: string): number {
   const stack = new Stack<string>();
   const output: string[] = [];
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -47,10 +47,6 @@ export function processOperator(
     // output.push(stack.pop());
     const operator = stack.pop();
 
-    if (operator === "(") {
-      return;
-    }
-
     const right = parseFloat(output.pop()!);
     const left = parseFloat(output.pop()!);
 
@@ -81,10 +77,6 @@ export function processRightBracket(stack: Stack<string>, output: string[]) {
   while (!stack.empty() && stack.peek() !== "(") {
     // output.push(stack.pop());
     const operator = stack.pop();
-
-    if (operator === "(") {
-      return;
-    }
 
     const right = parseFloat(output.pop()!);
     const left = parseFloat(output.pop()!);

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -128,10 +128,6 @@ export function parseAndEvaluate(expr: string): number {
     // output.push(stack.pop());
     const operator = stack.pop();
 
-    if (operator === "(") {
-      break;
-    }
-
     const right = parseFloat(output.pop()!);
     const left = parseFloat(output.pop()!);
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -101,7 +101,7 @@ export function parseAndEvaluate(expr: string): number {
  * @param output A buffer containing the intermediate results
  */
 export function evaluate(operator: string, output: string[]) {
-  if (output.length === 0) {
+  if (output.length < 2) {
     return;
   }
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -44,7 +44,29 @@ export function processOperator(
       (Operators[stack.peek()].precedence === Operators[operator].precedence &&
         Operators[operator].associativity === "left"))
   ) {
-    output.push(stack.pop());
+    // output.push(stack.pop());
+    const operator = stack.pop();
+
+    if (operator === "(") {
+      return;
+    }
+
+    const right = parseFloat(output.pop()!);
+    const left = parseFloat(output.pop()!);
+
+    if (operator === "-") {
+      output.push(subtract(left, right).toString());
+    } else if (operator === "+") {
+      output.push(add(left, right).toString());
+    } else if (operator === "×") {
+      output.push(multiply(left, right).toString());
+    } else if (operator === "÷") {
+      output.push(divide(left, right).toString());
+    } else if (operator === "^") {
+      output.push((left ** right).toString());
+    } else {
+      throw new Error(`Invalid operation: ${operator}`);
+    }
   }
 
   stack.push(operator);
@@ -57,7 +79,29 @@ export function processOperator(
  */
 export function processRightBracket(stack: Stack<string>, output: string[]) {
   while (!stack.empty() && stack.peek() !== "(") {
-    output.push(stack.pop());
+    // output.push(stack.pop());
+    const operator = stack.pop();
+
+    if (operator === "(") {
+      return;
+    }
+
+    const right = parseFloat(output.pop()!);
+    const left = parseFloat(output.pop()!);
+
+    if (operator === "-") {
+      output.push(subtract(left, right).toString());
+    } else if (operator === "+") {
+      output.push(add(left, right).toString());
+    } else if (operator === "×") {
+      output.push(multiply(left, right).toString());
+    } else if (operator === "÷") {
+      output.push(divide(left, right).toString());
+    } else if (operator === "^") {
+      output.push((left ** right).toString());
+    } else {
+      throw new Error(`Invalid operation: ${operator}`);
+    }
   }
 
   stack.pop();
@@ -68,7 +112,7 @@ export function processRightBracket(stack: Stack<string>, output: string[]) {
  * @param expr The mathematical expression in infix form to be parsed
  * @returns The expression in Reverse Polish Notation
  */
-export function parse(expr: string): string[] {
+export function parse(expr: string): number {
   const stack = new Stack<string>();
   const output: string[] = [];
 
@@ -89,10 +133,32 @@ export function parse(expr: string): string[] {
   }
 
   while (!stack.empty()) {
-    output.push(stack.pop());
+    // output.push(stack.pop());
+    const operator = stack.pop();
+
+    if (operator === "(") {
+      break;
+    }
+
+    const right = parseFloat(output.pop()!);
+    const left = parseFloat(output.pop()!);
+
+    if (operator === "-") {
+      output.push(subtract(left, right).toString());
+    } else if (operator === "+") {
+      output.push(add(left, right).toString());
+    } else if (operator === "×") {
+      output.push(multiply(left, right).toString());
+    } else if (operator === "÷") {
+      output.push(divide(left, right).toString());
+    } else if (operator === "^") {
+      output.push((left ** right).toString());
+    } else {
+      throw new Error(`Invalid operation: ${operator}`);
+    }
   }
 
-  return output;
+  return parseFloat(output[0]);
 }
 
 /**

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -45,24 +45,7 @@ export function processOperator(
         Operators[operator].associativity === "left"))
   ) {
     // output.push(stack.pop());
-    const operator = stack.pop();
-
-    const right = parseFloat(output.pop()!);
-    const left = parseFloat(output.pop()!);
-
-    if (operator === "-") {
-      output.push(subtract(left, right).toString());
-    } else if (operator === "+") {
-      output.push(add(left, right).toString());
-    } else if (operator === "×") {
-      output.push(multiply(left, right).toString());
-    } else if (operator === "÷") {
-      output.push(divide(left, right).toString());
-    } else if (operator === "^") {
-      output.push((left ** right).toString());
-    } else {
-      throw new Error(`Invalid operation: ${operator}`);
-    }
+    evaluate(stack.pop(), output);
   }
 
   stack.push(operator);
@@ -76,24 +59,7 @@ export function processOperator(
 export function processRightBracket(stack: Stack<string>, output: string[]) {
   while (!stack.empty() && stack.peek() !== "(") {
     // output.push(stack.pop());
-    const operator = stack.pop();
-
-    const right = parseFloat(output.pop()!);
-    const left = parseFloat(output.pop()!);
-
-    if (operator === "-") {
-      output.push(subtract(left, right).toString());
-    } else if (operator === "+") {
-      output.push(add(left, right).toString());
-    } else if (operator === "×") {
-      output.push(multiply(left, right).toString());
-    } else if (operator === "÷") {
-      output.push(divide(left, right).toString());
-    } else if (operator === "^") {
-      output.push((left ** right).toString());
-    } else {
-      throw new Error(`Invalid operation: ${operator}`);
-    }
+    evaluate(stack.pop(), output);
   }
 
   stack.pop();
@@ -126,24 +92,7 @@ export function parseAndEvaluate(expr: string): number {
 
   while (!stack.empty() && stack.peek() != "(") {
     // output.push(stack.pop());
-    const operator = stack.pop();
-
-    const right = parseFloat(output.pop()!);
-    const left = parseFloat(output.pop()!);
-
-    if (operator === "-") {
-      output.push(subtract(left, right).toString());
-    } else if (operator === "+") {
-      output.push(add(left, right).toString());
-    } else if (operator === "×") {
-      output.push(multiply(left, right).toString());
-    } else if (operator === "÷") {
-      output.push(divide(left, right).toString());
-    } else if (operator === "^") {
-      output.push((left ** right).toString());
-    } else {
-      throw new Error(`Invalid operation: ${operator}`);
-    }
+    evaluate(stack.pop(), output);
   }
 
   return parseFloat(output[0]);

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -35,7 +35,7 @@ export function isNumber(expr: string): boolean {
 export function processOperator(
   operator: string,
   stack: Stack<string>,
-  output: string[]
+  output: number[]
 ) {
   while (
     !stack.empty() &&
@@ -55,7 +55,7 @@ export function processOperator(
  * @param stack The stack containing tokens
  * @param output The array containing the result of calling this function
  */
-export function processRightBracket(stack: Stack<string>, output: string[]) {
+export function processRightBracket(stack: Stack<string>, output: number[]) {
   while (!stack.empty() && stack.peek() !== "(") {
     evaluate(stack.pop(), output);
   }
@@ -70,13 +70,13 @@ export function processRightBracket(stack: Stack<string>, output: string[]) {
  */
 export function parseAndEvaluate(expr: string): number {
   const stack = new Stack<string>();
-  const output: string[] = [];
+  const output: number[] = [];
 
   for (let char of expr) {
     if (char == " ") {
       continue;
     } else if (isNumber(char)) {
-      output.push(char);
+      output.push(parseFloat(char));
     } else if (isOperator(char)) {
       processOperator(char, stack, output);
     } else if (char == "(") {
@@ -92,7 +92,7 @@ export function parseAndEvaluate(expr: string): number {
     evaluate(stack.pop(), output);
   }
 
-  return parseFloat(output[0]);
+  return output[0];
 }
 
 /**
@@ -100,24 +100,24 @@ export function parseAndEvaluate(expr: string): number {
  * @param operator The arithmetic operator
  * @param output A buffer containing the intermediate results
  */
-export function evaluate(operator: string, output: string[]) {
+export function evaluate(operator: string, output: number[]) {
   if (output.length < 2) {
     return;
   }
 
-  const right = parseFloat(output.pop()!);
-  const left = parseFloat(output.pop()!);
+  const right = output.pop()!;
+  const left = output.pop()!;
 
   if (operator === "-") {
-    output.push(subtract(left, right).toString());
+    output.push(subtract(left, right));
   } else if (operator === "+") {
-    output.push(add(left, right).toString());
+    output.push(add(left, right));
   } else if (operator === "×") {
-    output.push(multiply(left, right).toString());
+    output.push(multiply(left, right));
   } else if (operator === "÷") {
-    output.push(divide(left, right).toString());
+    output.push(divide(left, right));
   } else if (operator === "^") {
-    output.push((left ** right).toString());
+    output.push(left ** right);
   } else {
     throw new Error(`Invalid operation: ${operator}`);
   }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -44,7 +44,6 @@ export function processOperator(
       (Operators[stack.peek()].precedence === Operators[operator].precedence &&
         Operators[operator].associativity === "left"))
   ) {
-    // output.push(stack.pop());
     evaluate(stack.pop(), output);
   }
 
@@ -58,7 +57,6 @@ export function processOperator(
  */
 export function processRightBracket(stack: Stack<string>, output: string[]) {
   while (!stack.empty() && stack.peek() !== "(") {
-    // output.push(stack.pop());
     evaluate(stack.pop(), output);
   }
 
@@ -91,7 +89,6 @@ export function parseAndEvaluate(expr: string): number {
   }
 
   while (!stack.empty() && stack.peek() != "(") {
-    // output.push(stack.pop());
     evaluate(stack.pop(), output);
   }
 


### PR DESCRIPTION
We merge the process of converting a given infix notation expression into postfix
notation and then later evaluating it into a single step. We also convert the 
output array into an array of numbers, rather than strings

- **feat: evaluate expressions as they are parsed**
- **refactor: delete call to function evaluate in printDisplay**
- **test: pass failing test**
- **test: delete evaluate function test cases**
- **chore: remove unused import**
- **chore: delete unused import**
- **refactor: delete function evaluate**
- **refactor: rename function parse to parseAndEvaluate**
- **test: rename the test suite and test case for parseAndEvaluate function**
- **docs: update comments for function parseAndEvaluate**
- **refactor: delete redundant check for "(" operator**
- **refactor: check for presence of "(" operator before executing loop body**
- **refactor: remove check for "(" operator in while loop body**
- **feat: add function evaluate**
- **refactor: use function evaluate in while loop bodies**
- **chore: delete commented-out code**
- **feat: return early from evaluate if the output array is empty**
- **test: add test case verifying the early return behaviour of function evaluate**
- **refactor: return early from evaluate if the output array has less than 2 entries**
- **test: rename evaluate function test case**
- **test: add other test cases for function evaluate**
- **test: replace toEqual object comparisons with toStrictEqual**
- **test: replace toEqual string comparison with toBe**
- **test: pass failing processRightBracket test**
- **test: pass failing processOperator test case**
- **test: rename test case and update its expectations to reflect change**
- **test: add new test case to processOperator test suite**
- **test: add new test case to processRightBracket test suite**
- **test: rename processRightBracket test case and update expectations to match**
- **test: pass appropriate data to stack object instance**
- **refactor: make the output array a number[] rather than a string[]**
- **test: pass failing tests by converting output to a number[]**
- **test: pass failing processRightBracket test case**
