### PR TITLE
Fix rendering of project by GitHub Actions

### DIFF
--- a/.github/workflows/DeployToGithubPages.yaml
+++ b/.github/workflows/DeployToGithubPages.yaml
@@ -6,9 +6,9 @@ name: Deploy static content to GitHub Pages
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/DeployToGithubPages.yaml
+++ b/.github/workflows/DeployToGithubPages.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npm run build && npm run preview
+        run: npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/.github/workflows/DeployToGithubPages.yaml
+++ b/.github/workflows/DeployToGithubPages.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npm run build
+        run: npm run build && npm run preview
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  base: "./",
+  base: "/Calculator/",
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  base: "./dist",
+  base: "./",
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./dist",
+});


### PR DESCRIPTION
We set the base path to the name of the project in order to enable the
built CSS and JS files be properly included by the index.html file
when opened.

- **ci: trigger workflow run on push and pull requests to dev branch**
- **ci: run preview script on build**
- **ci: remove npm run preview script from build action**
- **build: set dist as the base path**
- **build: set "./" as the base path**
- **build: set "./" as the base path**
- **build: set base to Calculator**
